### PR TITLE
Fixed: equal scale along all axes

### DIFF
--- a/Visualizer/visualizer_utils.py
+++ b/Visualizer/visualizer_utils.py
@@ -96,6 +96,7 @@ def create_mesh_figure(v, f, name, width, height, showLines=False, ref_figure = 
         scene_zaxis_visible=False,
         # paper_bgcolor='rgb(50,50,50)',
         margin=dict(l=0,r=0,t=30,b=0),
+        scene=dict(aspectmode='data')
     )
 
     if showLines:


### PR DESCRIPTION
aspectmode='cube', the scene’s axes are drawn as a cube, regardless of the axes’ ranges
aspectmode='data' preserves the proportion of axes ranges
'manual' when you set the aspectratio,
'auto' the scene’s axes are drawn with 'data', except when one axis is more than four times the size of the two others; in that case the 'cube' is used.